### PR TITLE
deprecated_member_use 警告の解決とカラー透明化メソッドの更新

### DIFF
--- a/lib/edit_page.dart
+++ b/lib/edit_page.dart
@@ -312,8 +312,7 @@ class EditPageState extends State<EditPage> {
                                   ],
                                 ),
                                 selected: selectedQuiz?.id == quiz.id,
-                                // ignore: deprecated_member_use
-                                selectedTileColor: Colors.blue.withOpacity(0.1),
+                                selectedTileColor: Colors.blue.withValues(alpha: 0.1 * 255),
                               );
                             },
                           ),

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -47,8 +47,7 @@ class HomePage extends StatelessWidget {
                         'Test your English knowledge',
                         style: TextStyle(
                           fontSize: 16,
-                          // ignore: deprecated_member_use
-                          color: Colors.white.withOpacity(0.9),
+                          color: Colors.white.withValues(alpha: 0.9 * 255),
                         ),
                       ),
                       const SizedBox(height: 48),

--- a/lib/quiz_page.dart
+++ b/lib/quiz_page.dart
@@ -312,8 +312,7 @@ class QuizPageState extends State<QuizPage>
                   borderRadius: BorderRadius.circular(8),
                   child: LinearProgressIndicator(
                     value: timeLeft,
-                    // ignore: deprecated_member_use
-                    backgroundColor: Colors.white.withOpacity(0.3),
+                    backgroundColor: Colors.white.withValues(alpha: 0.3 * 255),
                     color: Colors.white,
                     minHeight: 8,
                   ),


### PR DESCRIPTION
色の不透明度メソッドを新しいアプローチに更新することで、非推奨メンバーの使用に関する警告を排除。